### PR TITLE
Drop ApiResourceId column from ApiScopes

### DIFF
--- a/MSSQL/AlterExistingTables.sql
+++ b/MSSQL/AlterExistingTables.sql
@@ -68,6 +68,9 @@ ALTER TABLE ApiScopes
 	
 DROP INDEX IX_ApiScopes_ApiResourceId
 	ON ApiScopes
+
+ALTER TABLE ApiScopes
+DROP COLUMN ApiResourceId;
 	
 --MSSQL
 

--- a/MSSQL/MigrateData.sql
+++ b/MSSQL/MigrateData.sql
@@ -72,3 +72,9 @@ GO
 
 SET IDENTITY_INSERT IdentityResourceProperties OFF;  
 GO
+
+-- ApiScopes -> ApiResourceScopes
+INSERT INTO configuration.ApiResourceScopes (Scope, ApiResourceId)
+SELECT Name, ApiResourceId
+FROM configuration.ApiScopes
+GO

--- a/MSSQL/MigrateData.sql
+++ b/MSSQL/MigrateData.sql
@@ -74,7 +74,7 @@ SET IDENTITY_INSERT IdentityResourceProperties OFF;
 GO
 
 -- ApiScopes -> ApiResourceScopes
-INSERT INTO configuration.ApiResourceScopes (Scope, ApiResourceId)
+INSERT INTO ApiResourceScopes (Scope, ApiResourceId)
 SELECT Name, ApiResourceId
-FROM configuration.ApiScopes
+FROM ApiScopes
 GO


### PR DESCRIPTION
I have been testing the scripts and all work fine except the column ApiResourceId in ApiScopes table.

** EDIT: I add scopes into ApiResourceScopes to not break compatibility